### PR TITLE
Use output ItemStack in Mincer

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/MincerBlockEntity.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/entity/MincerBlockEntity.java
@@ -111,8 +111,7 @@ public class MincerBlockEntity extends RandomizableContainerBlockEntity implemen
     private void dropItemsInOutputSlot(Level level, BlockPos pos, BlockState state, MincerBlockEntity mincer) {
         Direction direction = state.getValue(MincerBlock.FACING).getClockWise();
         if (!level.isClientSide() && !this.stacks.get(OUTPUT_SLOT).isEmpty()) {
-            ItemStack droppedStack = new ItemStack(mincer.stacks.get(OUTPUT_SLOT).getItem());
-            droppedStack.setCount(mincer.stacks.get(OUTPUT_SLOT).getCount());
+            ItemStack droppedStack = mincer.stacks.get(OUTPUT_SLOT);
             this.stacks.set(OUTPUT_SLOT, ItemStack.EMPTY);
             Vec3 vec3d = Vec3.atCenterOf(pos);
             Vec3 vec3d2 = vec3d.relative(direction, 0.7);


### PR DESCRIPTION
I discovered this issue when trying to figure out why data components weren't getting copied during the recipe assembly phase. The issue is that the old approach loses any data components on output. The recipe assembly process provides copies of `ItemStack` so theres no need to copy it here (unless another mod decides to violate this).

You can see this fixes the issue here:
<img width="977" height="293" alt="image" src="https://github.com/user-attachments/assets/8121da67-7396-447f-8649-229cf3f49a9c" />

The `Max Health: +2` comes from my mod forwarding the data component from beef -> minced beef.
<img width="557" height="280" alt="image" src="https://github.com/user-attachments/assets/0f72640c-248c-43aa-9a44-fc16538e429f" />

I'm not sure if there were other reasons for manually copying the ItemStack here so let me know cause the alternative is copying over all the data components, but afaik that is wasted work.