### PR TITLE
Fix rope support logic for tomato crops

### DIFF
--- a/common/src/main/java/net/satisfy/farm_and_charm/core/block/crops/TomatoCropHeadBlock.java
+++ b/common/src/main/java/net/satisfy/farm_and_charm/core/block/crops/TomatoCropHeadBlock.java
@@ -40,7 +40,10 @@ public class TomatoCropHeadBlock extends ClimbingCropBlock implements Bonemealab
     @Override
     public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos) {
         BlockState below = level.getBlockState(pos.below());
-        if (below.getBlock() instanceof TomatoCropHeadBlock || below.getBlock() instanceof TomatoCropBodyBlock) {
+        if (below.getBlock() instanceof TomatoCropBodyBlock) {
+            return true;
+        }
+        if (below.getBlock() instanceof TomatoCropHeadBlock) {
             return false;
         }
         return super.canSurvive(state, level, pos);


### PR DESCRIPTION
# Issue
When the tomato crop reaches its maximum height, the rope above it breaks but the rope attached to the crop is not affected. I do not know if this was an intented feature so as to make the rope a temporary support. I think it's more realistic for the rope to stay permanently. In any case, it does not make sense for the rope to just stand there without being attached to a support.

# Fix
The canSurvive method of the TomatoCropHead class returned false when the block below the head was a TomatoCropBody which means that a TomatoCropHead block breaks as soon as he appears so I simply changed the boolean logic of the method so that a TomatoCropHead stays intact when it appears.